### PR TITLE
refactor(blob-read-stream): improve slice handling and event listener setup

### DIFF
--- a/lib/blob-read-stream.js
+++ b/lib/blob-read-stream.js
@@ -16,21 +16,18 @@ class BlobReadStream extends Readable {
     super(streamOptions);
 
     this.blob = blob;
-    // Handle legacy browser slice methods with type safety
-    this.slice = blob.slice || 
-                 (blob.webkitSlice && blob.webkitSlice.bind(blob)) || 
-                 (blob.mozSlice && blob.mozSlice.bind(blob));
     this.start = 0;
     this.sync = synchronous || false;
 
     // Initialize FileReader based on sync preference
-    if (this.sync && typeof window !== 'undefined' && window.FileReaderSync) {
+    if (this.sync && typeof window !== 'undefined' && 'FileReaderSync' in window && window.FileReaderSync) {
       this.fileReader = new window.FileReaderSync();
     } else {
       this.fileReader = new FileReader();
       this.sync = false; // Force async if sync not available
-      this.fileReader.onload = (e) => this._onload(e);
-      this.fileReader.onerror = (e) => this._onerror(e);
+
+      this.fileReader.addEventListener('load', this._onload);
+      this.fileReader.addEventListener('error', this._onerror);
     }
   }
 
@@ -43,7 +40,7 @@ class BlobReadStream extends Readable {
   _read(size) {
     const start = this.start;
     const end = this.start = this.start + size;
-    const chunk = this.slice.call(this.blob, start, end);
+    const chunk = this.blob.slice(start, end);
 
     if (chunk.size) {
       if (this.sync) {
@@ -61,28 +58,27 @@ class BlobReadStream extends Readable {
   /**
    * Handle FileReader load event
    *
-   * @param {ProgressEvent} e - Load event
+   * @param {ProgressEvent<FileReader>} e - Load event
    * @api private
    */
-  _onload(e) {
-    if (e.target && e.target.result instanceof ArrayBuffer) {
+  _onload = (e) => {
+    if (e.target?.result instanceof ArrayBuffer) {
       const chunk = Buffer.from(new Uint8Array(e.target.result));
       this.push(chunk);
     }
-  }
+  };
 
   /**
    * Handle FileReader error event
    *
-   * @param {ProgressEvent} e - Error event
+   * @param {ProgressEvent<FileReader>} e - Error event
    * @api private
    */
-  _onerror(e) {
-    if (e.target && e.target.error) {
+  _onerror = (e) => {
+    if (e.target?.error) {
       this.emit('error', e.target.error);
     }
   }
 }
 
 module.exports = BlobReadStream;
-


### PR DESCRIPTION
This pull request refactors the `BlobReadStream` class in `lib/blob-read-stream.js` to modernize the codebase and improve maintainability. Key changes include removing support for legacy browser slice methods, replacing callback-based event handling with `addEventListener`, and modernizing method definitions with arrow functions.

### Modernization and code simplification:
* Removed support for legacy browser slice methods (`webkitSlice` and `mozSlice`) and updated to use the standard `blob.slice` method directly. [[1]](diffhunk://#diff-84d93e84662fa42721248bf690cd82491610d816bae6fe6ff4a5d1dc6b4a7a9bL19-R30) [[2]](diffhunk://#diff-84d93e84662fa42721248bf690cd82491610d816bae6fe6ff4a5d1dc6b4a7a9bL46-R43)
* Replaced callback-based `onload` and `onerror` assignments with `addEventListener` for better event handling.

### Improved method definitions:
* Refactored `_onload` and `_onerror` methods to use arrow function syntax, enabling the use of optional chaining (`?.`) for cleaner null/undefined checks.