### PR TITLE
refactor(iostream): improve socket handling and code clarity

### DIFF
--- a/lib/iostream.js
+++ b/lib/iostream.js
@@ -179,7 +179,9 @@ class IOStream extends Duplex {
     // send 'end' event to remote
     this.socket?._end(this.id);
 
-    this._writableState.ended = true;
+    if (!this.writableEnded) {
+      this.end();
+    }
 
     if (!this.readable || this._readableState.ended) {
       debug('_onfinish: ended, destroy %s', this._readableState);
@@ -192,7 +194,7 @@ class IOStream extends Duplex {
       this.push(null);
 
       // just in case we're waiting for an EOF.
-      if (this.readable && !this._readableState.endEmitted) {
+      if (this.readable && !this.readableEnded) {
         this.read(0);
       }
     }
@@ -207,10 +209,12 @@ class IOStream extends Duplex {
    */
   _onend() {
     debug('_onend');
-    this._readableState.ended = true;
+    if (!this.readableEnded) {
+      this.push(null);
+    }
 
-    if (!this.writable || this._writableState.finished) {
-      debug('_onend: %s', this._writableState);
+    if (!this.writable || this.writableFinished) {
+      debug('_onend: %s', this.writableFinished);
       return this.destroy();
     }
 

--- a/lib/iostream.js
+++ b/lib/iostream.js
@@ -47,12 +47,7 @@ class IOStream extends Duplex {
       return this;
     }
 
-    if (!this.readableEnded) {
-      this.push(null);
-    }
-    if (!this.writableEnded) {
-      this.end();
-    }
+    super.destroy();
 
     if (this.socket) {
       debug('clean up');
@@ -60,7 +55,6 @@ class IOStream extends Duplex {
       this.socket = null;
     }
 
-    super.destroy(undefined);
     return this;
   }
 

--- a/lib/iostream.js
+++ b/lib/iostream.js
@@ -47,8 +47,12 @@ class IOStream extends Duplex {
       return this;
     }
 
-    this.push(null);
-    this.end();
+    if (!this.readableEnded) {
+      this.push(null);
+    }
+    if (!this.writableEnded) {
+      this.end();
+    }
 
     if (this.socket) {
       debug('clean up');
@@ -56,7 +60,7 @@ class IOStream extends Duplex {
       this.socket = null;
     }
 
-    super.destroy();
+    super.destroy(undefined);
     return this;
   }
 

--- a/lib/iostream.js
+++ b/lib/iostream.js
@@ -24,10 +24,9 @@ class IOStream extends Duplex {
     // Op states
     this._readable = false;
     this._writable = false;
-    this.destroyed = false;
 
     // default to *not* allowing half open sockets
-    this.allowHalfOpen = (options && options.allowHalfOpen) || false;
+    this.allowHalfOpen = options?.allowHalfOpen || false;
 
     this.on('finish', this._onfinish);
     this.on('end', this._onend);
@@ -48,7 +47,8 @@ class IOStream extends Duplex {
       return this;
     }
 
-    this.readable = this.writable = false;
+    this.push(null);
+    this.end();
 
     if (this.socket) {
       debug('clean up');
@@ -56,7 +56,7 @@ class IOStream extends Duplex {
       this.socket = null;
     }
 
-    this.destroyed = true;
+    super.destroy();
     return this;
   }
 
@@ -66,7 +66,7 @@ class IOStream extends Duplex {
    * @api private
    */
   _read(size) {
-    // We can not read from the socket if it's destroyed obviously ...
+    // We cannot read from the socket if it's destroyed obviously ...
     if (this.destroyed) return;
 
     if (this.pushBuffer.length) {
@@ -105,7 +105,7 @@ class IOStream extends Duplex {
    */
   _write(chunk, encoding, callback) {
     const write = () => {
-      // We can not write to the socket if it's destroyed obviously ...
+      // We cannot write to the socket if it's destroyed obviously ...
       if (this.destroyed) return;
 
       this._writable = false;
@@ -179,11 +179,8 @@ class IOStream extends Duplex {
     debug('_onfinish');
     // Local socket just finished
     // send 'end' event to remote
-    if (this.socket) {
-      this.socket._end(this.id);
-    }
+    this.socket?._end(this.id);
 
-    this.writable = false;
     this._writableState.ended = true;
 
     if (!this.readable || this._readableState.ended) {
@@ -212,7 +209,6 @@ class IOStream extends Duplex {
    */
   _onend() {
     debug('_onend');
-    this.readable = false;
     this._readableState.ended = true;
 
     if (!this.writable || this._writableState.finished) {


### PR DESCRIPTION
This pull request refactors the `IOStream` class in `lib/iostream.js` to improve code clarity, modernize syntax, and ensure proper resource cleanup. The most important changes include replacing manual state management with built-in mechanisms, using optional chaining for safer property access, and simplifying the handling of socket events.

### Code modernization and cleanup:

* Replaced manual state management (`destroyed`, `readable`, and `writable` flags) with built-in mechanisms like `super.destroy()` and `this.push(null)` to ensure proper cleanup and reduce redundancy. [[1]](diffhunk://#diff-69a9a8d218283ac30e1cb44e13ac64c829da79afbb5e2baca0ffdedee0d6779bL51-R59) [[2]](diffhunk://#diff-69a9a8d218283ac30e1cb44e13ac64c829da79afbb5e2baca0ffdedee0d6779bL215)
* Updated the `allowHalfOpen` property initialization to use optional chaining (`options?.allowHalfOpen`) for cleaner and safer code.

### Improved socket handling:

* Simplified the `_onfinish` method by using optional chaining (`this.socket?._end(this.id)`) to handle cases where the socket may not exist.